### PR TITLE
feat: add RTL support

### DIFF
--- a/_layouts/lecture.html
+++ b/_layouts/lecture.html
@@ -2,21 +2,24 @@
 layout: default
 ---
 
-<h1 class="title">{{ page.title }}{% if page.subtitle %} <span class="subtitle">{{ page.subtitle }}</span>{% endif %}</h1>
 
-{% if page.video.id %}
-  <div class="youtube-wrapper" style="padding-bottom: {{ page.video.aspect }}%;">
-    <iframe src="https://www.youtube.com/embed/{{ page.video.id }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div class="{{ page.direction }}">
+  <h1 class="title">{{ page.title }}{% if page.subtitle %} <span class="subtitle">{{ page.subtitle }}</span>{% endif %}</h1>
+
+  {% if page.video.id %}
+    <div class="youtube-wrapper" style="padding-bottom: {{ page.video.aspect }}%;">
+      <iframe src="https://www.youtube.com/embed/{{ page.video.id }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+  {% elsif page.video %}
+    <p class="center gap accent"><strong>Lecture video coming soon!</strong></p>
+  {% endif %}
+
+  {{ content }}
+
+  <hr>
+
+  <div class="small center">
+  <p><a href="https://github.com/missing-semester/missing-semester/blob/master/{{ page.path }}">Edit this page</a>.</p>
+  <p>Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0">CC BY-NC-SA</a>.</p>
   </div>
-{% elsif page.video %}
-  <p class="center gap accent"><strong>Lecture video coming soon!</strong></p>
-{% endif %}
-
-{{ content }}
-
-<hr>
-
-<div class="small center">
-<p><a href="https://github.com/missing-semester/missing-semester/blob/master/{{ page.path }}">Edit this page</a>.</p>
-<p>Licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0">CC BY-NC-SA</a>.</p>
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,6 +2,8 @@
 layout: default
 ---
 
-<h1 class="title">{{ page.title }}{% if page.subtitle %} <span class="subtitle">{{ page.subtitle }}</span>{% endif %}</h1>
+<div class="{{ page.direction }}">
+  <h1 class="title">{{ page.title }}{% if page.subtitle %} <span class="subtitle">{{ page.subtitle }}</span>{% endif %}</h1>
 
-{{ content }}
+  {{ content }}
+</div>

--- a/index.md
+++ b/index.md
@@ -1,6 +1,8 @@
 ---
 layout: page
 title: ترم گمشده شما در علوم کامپیوتر
+# This property tells Jekyll that the page should be RTL by default
+direction: rtl
 ---
 
 کلاس‌ها به شما همه‌چیز درباره علوم کامپیوتر یاد می‌دهند. از سیستم‌عامل گرفته تا یادگیری ماشین.
@@ -25,7 +27,9 @@ Sign up for the IAP 2020 class by filling out this [registration form](https://f
 **Office hours**: 32-G9 lounge, 3pm--4pm (every day, right after lecture)
 {% endcomment %}
 
-<ul>
+
+<!-- This is a sample that shows you how you can have LTR in RTL markdown file (.ltr class) -->
+<ul class="ltr">
 {% assign lectures = site['2020'] | sort: 'date' %}
 {% for lecture in lectures %}
     {% if lecture.phony != true %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -166,6 +166,14 @@ hr {
 
 /* Classes */
 
+.rtl {
+  direction: rtl;
+}
+
+.ltr {
+  direction: ltr;
+}
+
 .title {
   font-size: 2rem;
 }


### PR DESCRIPTION
Hooray! Now you can have RTL text in your Docs.

### Usage:
- Adding ```direction``` tag to markdown file, makes the whole page RTL. in other words, it tells Jekyll that the page should be RTL by default. You can see an example in ```index.md``` file.

- Everywhere you wanna have LTR text, you can add ```.ltr``` class to whatever element that you want. You have an example in ```index.md``` file, lectures list section.

- If a page is LTR by default and you wanna write RTL text, just add ```.rtl``` class to a wrapper of the text.